### PR TITLE
Add Fit Craft skeleton React Native app

### DIFF
--- a/FitCraft/App.js
+++ b/FitCraft/App.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, useColorScheme, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+// Simple zustand store for theme preference
+const useStore = create(set => ({
+  darkMode: false,
+  toggleTheme: () => set(state => ({ darkMode: !state.darkMode })),
+}));
+
+function PlaceholderScreen({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+function MapScreen() {
+  return <PlaceholderScreen name="Map" />;
+}
+
+function SplashScreen() {
+  return <PlaceholderScreen name="Splash" />;
+}
+
+function DetailScreen() {
+  return <PlaceholderScreen name="Detail" />;
+}
+
+function CreateEditScreen() {
+  return <PlaceholderScreen name="Create/Edit" />;
+}
+
+function PurchaseScreen() {
+  return <PlaceholderScreen name="Purchase" />;
+}
+
+function OnboardingScreen() {
+  return <PlaceholderScreen name="Onboarding" />;
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  const scheme = useColorScheme();
+  const darkMode = useStore(state => state.darkMode);
+  return (
+    <NavigationContainer theme={darkMode || scheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Tab.Navigator>
+        <Tab.Screen name="Map" component={MapScreen} />
+        <Tab.Screen name="Detail" component={DetailScreen} />
+        <Tab.Screen name="Create" component={CreateEditScreen} />
+        <Tab.Screen name="Purchase" component={PurchaseScreen} />
+        <Tab.Screen name="Onboarding" component={OnboardingScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/FitCraft/README.md
+++ b/FitCraft/README.md
@@ -1,0 +1,10 @@
+# Fit Craft
+
+This is a minimal skeleton React Native app using Expo. It demonstrates:
+
+- Bottom tab navigation
+- Light/dark theme support
+- Placeholder screens: Map, Splash, Detail, Create/Edit, Purchase, Onboarding
+- zustand for state management
+
+All heavy features like Firebase integration, AR, audio/video, payments, and Lottie animations are left as placeholders for further implementation.

--- a/FitCraft/package.json
+++ b/FitCraft/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fitcraft",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "react-navigation": "^4.4.4",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "react-native-svg": "^13.4.0",
+    "zustand": "^4.3.9"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold basic React Native skeleton for Fit Craft app
- include placeholder navigation and screens with zustand state management

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ca9f0a1dc8332b28df1f6fb4dc58d