### PR TITLE
Add Habit Tracker sample app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.expo

--- a/HabitTrackerAICoach/App.js
+++ b/HabitTrackerAICoach/App.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Provider } from 'react-redux';
+import store from './src/store';
+import HomeScreen from './src/screens/HomeScreen';
+import AddHabitScreen from './src/screens/AddHabitScreen';
+import ProgressScreen from './src/screens/ProgressScreen';
+import AICoachScreen from './src/screens/AICoachScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="AddHabit" component={AddHabitScreen} />
+          <Stack.Screen name="Progress" component={ProgressScreen} />
+          <Stack.Screen name="AICoach" component={AICoachScreen} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </Provider>
+  );
+}

--- a/HabitTrackerAICoach/babel.config.js
+++ b/HabitTrackerAICoach/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/HabitTrackerAICoach/index.js
+++ b/HabitTrackerAICoach/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/HabitTrackerAICoach/package.json
+++ b/HabitTrackerAICoach/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "habit-tracker-ai-coach",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-redux": "^8.1.1",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-native-chart-kit": "^6.12.0",
+    "expo-status-bar": "^1.4.2"
+  }
+}

--- a/HabitTrackerAICoach/src/components/AIChatBubble.js
+++ b/HabitTrackerAICoach/src/components/AIChatBubble.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function AIChatBubble({ text, isUser }) {
+  return (
+    <View style={[styles.bubble, isUser ? styles.user : styles.ai]}>
+      <Text style={styles.text}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    padding: 12,
+    marginVertical: 4,
+    maxWidth: '80%',
+    borderRadius: 12,
+  },
+  ai: {
+    backgroundColor: '#e0e0e0',
+    alignSelf: 'flex-start',
+  },
+  user: {
+    backgroundColor: '#4e9bde',
+    alignSelf: 'flex-end',
+  },
+  text: {
+    color: '#000',
+  },
+});

--- a/HabitTrackerAICoach/src/components/HabitCard.js
+++ b/HabitTrackerAICoach/src/components/HabitCard.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+
+export default function HabitCard({ habit, onToggle }) {
+  return (
+    <TouchableOpacity style={styles.card} onPress={onToggle}>
+      <Text style={styles.title}>{habit.title}</Text>
+      <Text style={styles.streak}>Streak: {habit.streak}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    padding: 16,
+    marginVertical: 8,
+    borderRadius: 8,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  streak: {
+    marginTop: 4,
+    color: '#888',
+  },
+});

--- a/HabitTrackerAICoach/src/components/ProgressChart.js
+++ b/HabitTrackerAICoach/src/components/ProgressChart.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Dimensions } from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
+
+export default function ProgressChart({ data }) {
+  const screenWidth = Dimensions.get('window').width - 32;
+  return (
+    <LineChart
+      data={{ labels: data.map((_, i) => i + 1), datasets: [{ data }] }}
+      width={screenWidth}
+      height={220}
+      chartConfig={{
+        backgroundColor: '#fff',
+        backgroundGradientFrom: '#fff',
+        backgroundGradientTo: '#fff',
+        decimalPlaces: 0,
+        color: (opacity = 1) => `rgba(74,144,226, ${opacity})`,
+      }}
+    />
+  );
+}

--- a/HabitTrackerAICoach/src/screens/AICoachScreen.js
+++ b/HabitTrackerAICoach/src/screens/AICoachScreen.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, FlatList } from 'react-native';
+import AIChatBubble from '../components/AIChatBubble';
+
+export default function AICoachScreen() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+
+  const send = () => {
+    if (!input.trim()) return;
+    setMessages(m => [...m, { text: input, isUser: true }]);
+    setMessages(m => [...m, { text: 'Great job! Keep it up!', isUser: false }]);
+    setInput('');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={messages}
+        keyExtractor={(_, i) => i.toString()}
+        renderItem={({ item }) => <AIChatBubble {...item} />}
+      />
+      <TextInput
+        placeholder="Message"
+        value={input}
+        onChangeText={setInput}
+        style={{ borderWidth: 1, borderColor: '#ccc', borderRadius: 4, padding: 8 }}
+      />
+      <Button title="Send" onPress={send} />
+    </View>
+  );
+}

--- a/HabitTrackerAICoach/src/screens/AddHabitScreen.js
+++ b/HabitTrackerAICoach/src/screens/AddHabitScreen.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { useDispatch } from 'react-redux';
+import { addHabit } from '../store/habitsSlice';
+
+export default function AddHabitScreen({ navigation }) {
+  const [title, setTitle] = useState('');
+  const dispatch = useDispatch();
+
+  const add = () => {
+    if (title.trim()) {
+      dispatch(addHabit(title));
+      navigation.goBack();
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput
+        placeholder="Habit name"
+        value={title}
+        onChangeText={setTitle}
+        style={{ borderBottomWidth: 1, marginBottom: 16 }}
+      />
+      <Button title="Save" onPress={add} />
+    </View>
+  );
+}

--- a/HabitTrackerAICoach/src/screens/HomeScreen.js
+++ b/HabitTrackerAICoach/src/screens/HomeScreen.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, FlatList, Button } from 'react-native';
+import { useSelector, useDispatch } from 'react-redux';
+import HabitCard from '../components/HabitCard';
+import { toggleHabit } from '../store/habitsSlice';
+
+export default function HomeScreen({ navigation }) {
+  const habits = useSelector(state => state.habits);
+  const dispatch = useDispatch();
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Button title="Add Habit" onPress={() => navigation.navigate('AddHabit')} />
+      <FlatList
+        data={habits}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <HabitCard habit={item} onToggle={() => dispatch(toggleHabit(item.id))} />
+        )}
+      />
+      <Button title="Progress" onPress={() => navigation.navigate('Progress')} />
+      <Button title="AI Coach" onPress={() => navigation.navigate('AICoach')} />
+    </View>
+  );
+}

--- a/HabitTrackerAICoach/src/screens/ProfileScreen.js
+++ b/HabitTrackerAICoach/src/screens/ProfileScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function ProfileScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Profile Screen</Text>
+    </View>
+  );
+}

--- a/HabitTrackerAICoach/src/screens/ProgressScreen.js
+++ b/HabitTrackerAICoach/src/screens/ProgressScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View } from 'react-native';
+import { useSelector } from 'react-redux';
+import ProgressChart from '../components/ProgressChart';
+
+export default function ProgressScreen() {
+  const habits = useSelector(state => state.habits);
+  const data = habits.map(h => h.streak);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', padding: 16 }}>
+      <ProgressChart data={data} />
+    </View>
+  );
+}

--- a/HabitTrackerAICoach/src/store/habitsSlice.js
+++ b/HabitTrackerAICoach/src/store/habitsSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const habitsSlice = createSlice({
+  name: 'habits',
+  initialState: [],
+  reducers: {
+    addHabit: (state, action) => {
+      state.push({ id: Date.now().toString(), title: action.payload, streak: 0 });
+    },
+    toggleHabit: (state, action) => {
+      const habit = state.find(h => h.id === action.payload);
+      if (habit) {
+        habit.streak += 1;
+      }
+    },
+  },
+});
+
+export const { addHabit, toggleHabit } = habitsSlice.actions;
+export default habitsSlice.reducer;

--- a/HabitTrackerAICoach/src/store/index.js
+++ b/HabitTrackerAICoach/src/store/index.js
@@ -1,0 +1,6 @@
+import { configureStore } from '@reduxjs/toolkit';
+import habitsReducer from './habitsSlice';
+
+export default configureStore({
+  reducer: { habits: habitsReducer },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# Mobile-apps-online-
+# Mobile Apps Collection
+
+This repository contains sample React Native implementations inspired by various app ideas. Currently, a starter project for the **Habit Tracker with AI Coach** is provided under `HabitTrackerAICoach/`.
+
+Each project uses Expo and Redux for state management. Additional apps can be added following a similar structure.


### PR DESCRIPTION
## Summary
- bootstrap HabitTrackerAICoach Expo project
- implement example screens, components, and Redux store
- add basic README

## Testing
- `npm install` within `HabitTrackerAICoach`


------
https://chatgpt.com/codex/tasks/task_e_687ca7f3d62083329a40abbe688a639b