### PR TITLE
Add BreathSync app skeleton

### DIFF
--- a/BreathSync/App.js
+++ b/BreathSync/App.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import SessionPicker from './src/screens/SessionPicker';
+import ExercisePlayer from './src/screens/ExercisePlayer';
+import StatsScreen from './src/screens/StatsScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="SessionPicker" component={SessionPicker} options={{ title: 'BreathSync' }} />
+        <Stack.Screen name="Exercise" component={ExercisePlayer} />
+        <Stack.Screen name="Stats" component={StatsScreen} />
+        <Stack.Screen name="Settings" component={SettingsScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/BreathSync/README.md
+++ b/BreathSync/README.md
@@ -1,0 +1,3 @@
+# BreathSync
+
+Minimal starter for a guided breathing app. Includes stack navigation with placeholder screens and a sample component.

--- a/BreathSync/src/components/CircularTimer.js
+++ b/BreathSync/src/components/CircularTimer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function CircularTimer() {
+  // Placeholder for animated breathing circle
+  return (
+    <View>
+      <Text>Timer</Text>
+    </View>
+  );
+}

--- a/BreathSync/src/screens/ExercisePlayer.js
+++ b/BreathSync/src/screens/ExercisePlayer.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ExercisePlayer() {
+  return (
+    <View style={styles.container}>
+      <Text>Exercise Player Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/BreathSync/src/screens/SessionPicker.js
+++ b/BreathSync/src/screens/SessionPicker.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+
+export default function SessionPicker({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Button title="Start Breathing" onPress={() => navigation.navigate('Exercise')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/BreathSync/src/screens/SettingsScreen.js
+++ b/BreathSync/src/screens/SettingsScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Settings Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/BreathSync/src/screens/StatsScreen.js
+++ b/BreathSync/src/screens/StatsScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function StatsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Stats Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add new BreathSync example app with navigation
- scaffold session picker, exercise player, stats and settings screens
- add a placeholder circular timer component

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cc8ce07bc8332a315df7fb55fb541