### PR TITLE
Add DreamWeaverAI prototype

### DIFF
--- a/DreamWeaverAI/App.js
+++ b/DreamWeaverAI/App.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import create from 'zustand';
+import { StatusBar } from 'expo-status-bar';
+
+const useStore = create(set => ({ dreams: [], addDream: d => set(state => ({ dreams: [...state.dreams, d] })) }));
+
+function HomeScreen({ navigation }) {
+  const dreams = useStore(state => state.dreams);
+  return (
+    <View style={styles.center}>
+      <Text>DreamWeaver AI</Text>
+      <Button title="Add Dream" onPress={() => navigation.navigate('Entry')} />
+      {dreams.map((d, i) => (
+        <Text key={i}>{d.slice(0,20)}...</Text>
+      ))}
+
+    </View>
+  );
+}
+
+function EntryScreen({ navigation }) {
+  const addDream = useStore(state => state.addDream);
+  return (
+    <View style={styles.center}>
+      <Text>Dream Entry Placeholder</Text>
+      <Button title="Save" onPress={() => { addDream('My dream'); navigation.goBack(); }} />
+    </View>
+  );
+}
+
+function DictionaryScreen() {
+  return (
+    <View style={styles.center}>
+      <Text>Dream Dictionary Placeholder</Text>
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <StatusBar style="auto" />
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Entry" component={EntryScreen} />
+        <Stack.Screen name="Dictionary" component={DictionaryScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/DreamWeaverAI/README.md
+++ b/DreamWeaverAI/README.md
@@ -1,0 +1,9 @@
+# DreamWeaver AI
+
+This is a minimal React Native prototype built with Expo. It includes:
+
+- Stack navigation (Home, Entry, Dictionary)
+- Zustand for simple state management
+- Placeholder screens for future dream logging and interpretation features
+
+This skeleton can be expanded with Firebase integration, AI calls, secure storage, and other functionality as described in the SDD.

--- a/DreamWeaverAI/package.json
+++ b/DreamWeaverAI/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dreamweaver-ai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "zustand": "^4.3.9",
+    "expo-status-bar": "^1.4.2"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Mobile Apps Collection
 
-This repository contains sample React Native implementations inspired by various app ideas. Currently, a starter project for the **Habit Tracker with AI Coach** is provided under `HabitTrackerAICoach/`.
+This repository provides minimal React Native prototypes for various app ideas. Each project uses Expo and a simple state management approach.
 
-Each project uses Expo and Redux for state management. Additional apps can be added following a similar structure.
+Current examples:
+
+- **FitCraft** – skeleton app demonstrating bottom tab navigation and zustand.
+- **HabitTrackerAICoach** – sample habit tracker using Redux Toolkit.
+- **DreamWeaverAI** – basic stack navigation setup for dream journaling features.
+
+These prototypes can be expanded with Firebase, AI integrations, and additional screens as described in their respective README files.


### PR DESCRIPTION
## Summary
- create DreamWeaverAI with Expo and zustand
- basic stack navigation (Home, Entry, Dictionary)
- update repository README to list all available example apps

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687cd5bc20688332a2a06c6ad2839f1b