### PR TITLE
Add skeleton apps FitBuddy, MoodWave, SnapCook

### DIFF
--- a/FitBuddy/App.js
+++ b/FitBuddy/App.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Provider } from 'react-redux';
+import store from './src/store';
+import HomeScreen from './src/screens/HomeScreen';
+import ChallengesScreen from './src/screens/ChallengesScreen';
+import WorkoutScreen from './src/screens/WorkoutScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+import LeaderboardScreen from './src/screens/LeaderboardScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <NavigationContainer>
+        <Tab.Navigator>
+          <Tab.Screen name="Home" component={HomeScreen} />
+          <Tab.Screen name="Challenges" component={ChallengesScreen} />
+          <Tab.Screen name="Workout" component={WorkoutScreen} />
+          <Tab.Screen name="Leaderboard" component={LeaderboardScreen} />
+          <Tab.Screen name="Profile" component={ProfileScreen} />
+        </Tab.Navigator>
+      </NavigationContainer>
+    </Provider>
+  );
+}

--- a/FitBuddy/README.md
+++ b/FitBuddy/README.md
@@ -1,0 +1,3 @@
+# FitBuddy
+
+Minimal prototype for a social fitness tracker. Uses Expo, React Navigation and Redux Toolkit. Screens are simple placeholders for dashboard, challenges, workout timer, profile and leaderboard. Firebase integration and wearables support are left as future enhancements.

--- a/FitBuddy/package.json
+++ b/FitBuddy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fitbuddy",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/stack": "^6.3.16",
+    "react-redux": "^8.0.5",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "lottie-react-native": "^5.1.4",
+    "react-native-svg": "^13.4.0"
+  }
+}

--- a/FitBuddy/src/screens/ChallengesScreen.js
+++ b/FitBuddy/src/screens/ChallengesScreen.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+
+export default function ChallengesScreen() {
+  const challenges = useSelector(state => state.challenges);
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={challenges}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text>{item.goal}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  item: { padding: 12, borderBottomWidth: 1 },
+});

--- a/FitBuddy/src/screens/HomeScreen.js
+++ b/FitBuddy/src/screens/HomeScreen.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FitBuddy</Text>
+      <Button title="Start Workout" onPress={() => navigation.navigate('Workout')} />
+      <Button title="Invite Friends" onPress={() => navigation.navigate('Challenges')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16 },
+});

--- a/FitBuddy/src/screens/LeaderboardScreen.js
+++ b/FitBuddy/src/screens/LeaderboardScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function LeaderboardScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Leaderboard Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/FitBuddy/src/screens/ProfileScreen.js
+++ b/FitBuddy/src/screens/ProfileScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+
+export default function ProfileScreen() {
+  const user = useSelector(state => state.user);
+
+  return (
+    <View style={styles.container}>
+      <Text>{user.name || 'Guest'}</Text>
+      <Text>Badges: {user.badges.length}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/FitBuddy/src/screens/WorkoutScreen.js
+++ b/FitBuddy/src/screens/WorkoutScreen.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function WorkoutScreen() {
+  const [running, setRunning] = useState(false);
+  const [time, setTime] = useState(0);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.timer}>{time}s</Text>
+      <Button title={running ? 'Stop' : 'Start'} onPress={() => setRunning(!running)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  timer: { fontSize: 48, marginBottom: 16 },
+});

--- a/FitBuddy/src/store/challengeSlice.js
+++ b/FitBuddy/src/store/challengeSlice.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const challengeSlice = createSlice({
+  name: 'challenges',
+  initialState: [],
+  reducers: {
+    addChallenge: (state, action) => {
+      state.push(action.payload);
+    },
+  },
+});
+
+export const { addChallenge } = challengeSlice.actions;
+export default challengeSlice.reducer;

--- a/FitBuddy/src/store/index.js
+++ b/FitBuddy/src/store/index.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import userReducer from './userSlice';
+import challengeReducer from './challengeSlice';
+
+export default configureStore({
+  reducer: {
+    user: userReducer,
+    challenges: challengeReducer,
+  },
+});

--- a/FitBuddy/src/store/userSlice.js
+++ b/FitBuddy/src/store/userSlice.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState: { id: '', name: '', avatar: '', badges: [] },
+  reducers: {
+    setUser: (state, action) => {
+      Object.assign(state, action.payload);
+    },
+  },
+});
+
+export const { setUser } = userSlice.actions;
+export default userSlice.reducer;

--- a/MoodWave/App.js
+++ b/MoodWave/App.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import HomeScreen from './src/screens/HomeScreen';
+import MindfulnessScreen from './src/screens/MindfulnessScreen';
+import CommunityScreen from './src/screens/CommunityScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Home" component={HomeScreen} />
+        <Tab.Screen name="Mindfulness" component={MindfulnessScreen} />
+        <Tab.Screen name="Community" component={CommunityScreen} />
+        <Tab.Screen name="Profile" component={ProfileScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/MoodWave/README.md
+++ b/MoodWave/README.md
@@ -1,0 +1,3 @@
+# MoodWave
+
+Prototype emotional wellness app using Expo and Zustand. Includes basic screens for daily mood check-ins, mindfulness content, community forum placeholder and profile analytics. Supabase integration and AI-generated exercises are not included in this demo.

--- a/MoodWave/package.json
+++ b/MoodWave/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "moodwave",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/MoodWave/src/screens/CommunityScreen.js
+++ b/MoodWave/src/screens/CommunityScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function CommunityScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Community Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/MoodWave/src/screens/HomeScreen.js
+++ b/MoodWave/src/screens/HomeScreen.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, Text, Button, StyleSheet, TextInput } from 'react-native';
+import { useMoodStore } from '../store/moodStore';
+
+const moods = ['Happy', 'Sad', 'Anxious', 'Excited'];
+
+export default function HomeScreen() {
+  const [selected, setSelected] = useState(moods[0]);
+  const [notes, setNotes] = useState('');
+  const addMood = useMoodStore(state => state.addMood);
+
+  const save = () => {
+    addMood({ date: new Date().toISOString(), mood: selected, notes });
+    setNotes('');
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Today's Mood</Text>
+      {moods.map(m => (
+        <Button key={m} title={m} onPress={() => setSelected(m)} />
+      ))}
+      <TextInput style={styles.input} placeholder="Notes" value={notes} onChangeText={setNotes} />
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
+  title: { fontSize: 20, marginBottom: 8 },
+  input: { borderWidth: 1, width: '100%', marginVertical: 8, padding: 8 },
+});

--- a/MoodWave/src/screens/MindfulnessScreen.js
+++ b/MoodWave/src/screens/MindfulnessScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function MindfulnessScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Mindfulness Exercises Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/MoodWave/src/screens/ProfileScreen.js
+++ b/MoodWave/src/screens/ProfileScreen.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useMoodStore } from '../store/moodStore';
+
+export default function ProfileScreen() {
+  const moods = useMoodStore(state => state.moods);
+
+  return (
+    <View style={styles.container}>
+      <Text>Entries: {moods.length}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/MoodWave/src/store/moodStore.js
+++ b/MoodWave/src/store/moodStore.js
@@ -1,0 +1,6 @@
+import create from 'zustand';
+
+export const useMoodStore = create(set => ({
+  moods: [],
+  addMood: (entry) => set(state => ({ moods: [entry, ...state.moods] })),
+}));

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Mobile Apps Collection
 
-This repository contains sample React Native implementations inspired by various app ideas. Currently, a starter project for the **Habit Tracker with AI Coach** is provided under `HabitTrackerAICoach/`.
+This repository contains minimal React Native prototypes for various app ideas built with Expo.
 
-Each project uses Expo and Redux for state management. Additional apps can be added following a similar structure.
-- **VibePulse**: simple mood tracker demo under `VibePulse/`.
+Available samples:
+
+- **BreathSync**: guided breathing app skeleton.
+- **FitCraft**: navigation and theming demo.
+- **HabitTrackerAICoach**: habit tracker with basic Redux setup.
+- **VibePulse**: simple mood tracker using Redux Toolkit.
+- **FitBuddy**: social fitness tracker starter with Redux.
+- **MoodWave**: emotional wellness app using Zustand.
+- **SnapCook**: recipe generator concept with camera placeholder.
+
+These projects include only core screens and state management. Features like backend integration, payments, AI services and animations are left for future expansion.

--- a/SnapCook/App.js
+++ b/SnapCook/App.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/stack';
+import HomeScreen from './src/screens/HomeScreen';
+import RecipesScreen from './src/screens/RecipesScreen';
+import GroceryScreen from './src/screens/GroceryScreen';
+import ProfileScreen from './src/screens/ProfileScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Recipes" component={RecipesScreen} />
+        <Stack.Screen name="Grocery" component={GroceryScreen} />
+        <Stack.Screen name="Profile" component={ProfileScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/SnapCook/README.md
+++ b/SnapCook/README.md
@@ -1,0 +1,3 @@
+# SnapCook
+
+Skeleton app for generating recipes from ingredient photos. Built with Expo and React Navigation. Contains basic navigation between a home screen, generated recipes list, grocery checklist and profile. Image recognition, backend services and detailed recipe views are omitted in this starter.

--- a/SnapCook/package.json
+++ b/SnapCook/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "snapcook",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/stack": "^6.3.16",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "expo-camera": "^13.2.1"
+  }
+}

--- a/SnapCook/src/screens/GroceryScreen.js
+++ b/SnapCook/src/screens/GroceryScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function GroceryScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Grocery List Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/SnapCook/src/screens/HomeScreen.js
+++ b/SnapCook/src/screens/HomeScreen.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>SnapCook</Text>
+      <Button title="Take Picture" onPress={() => navigation.navigate('Recipes')} />
+      <Button title="Grocery List" onPress={() => navigation.navigate('Grocery')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16 },
+});

--- a/SnapCook/src/screens/ProfileScreen.js
+++ b/SnapCook/src/screens/ProfileScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function ProfileScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Profile Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/SnapCook/src/screens/RecipesScreen.js
+++ b/SnapCook/src/screens/RecipesScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+
+export default function RecipesScreen() {
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={[]}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <Text>{item.title}</Text>}
+        ListEmptyComponent={<Text>No recipes yet</Text>}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+});


### PR DESCRIPTION
## Summary
- add new sample apps FitBuddy, MoodWave and SnapCook with placeholder screens and Redux/Zustand stores
- update repository README with list of available demo apps

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_687cd729ef348332918f080b75f200f4