### PR TITLE
Add skeleton apps for AuraSnap through StorySphere

### DIFF
--- a/AuraSnap/App.js
+++ b/AuraSnap/App.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { Camera } from 'expo-camera';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  premium: false,
+  togglePremium: () => set(state => ({ premium: !state.premium }))
+}));
+
+function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.center}>
+      <Text>AuraSnap Home (Camera Placeholder)</Text>
+      <Button title="Capture" onPress={() => navigation.navigate('Loading')} />
+    </View>
+  );
+}
+
+function LoadingScreen({ navigation }) {
+  React.useEffect(() => {
+    const timeout = setTimeout(() => navigation.navigate('Preview'), 1000);
+    return () => clearTimeout(timeout);
+  }, [navigation]);
+  return (
+    <View style={styles.center}>
+      <Text>Reading your energy...</Text>
+    </View>
+  );
+}
+
+function PreviewScreen() {
+  const premium = useStore(state => state.premium);
+  const toggle = useStore(state => state.togglePremium);
+  return (
+    <View style={styles.center}>
+      <Text>Preview Placeholder</Text>
+      <Button title={premium ? 'Premium Active' : 'Unlock Premium'} onPress={toggle} />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Loading" component={LoadingScreen} />
+        <Stack.Screen name="Preview" component={PreviewScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/AuraSnap/README.md
+++ b/AuraSnap/README.md
@@ -1,0 +1,10 @@
+# AuraSnap
+
+Minimal Expo prototype for the **AuraSnap** concept. This app demonstrates stack navigation with Zust and camera placeholder screens.
+
+Features stubbed:
+- Camera capture
+- Aura generation and style carousel
+- Premium unlock flow
+
+Use this as a starting point to add Firebase functions and AI image processing.

--- a/AuraSnap/package.json
+++ b/AuraSnap/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "aurasnap",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "zustand": "^4.5.2",
+    "expo-camera": "^14.1.0",
+    "react-native-reanimated": "^3.3.0"
+  }
+}

--- a/CritterQuest/App.js
+++ b/CritterQuest/App.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({ discoveries: [] }));
+
+function MapScreen({ navigation }) {
+  return (
+    <View style={styles.center}>
+      <Text>Map Placeholder</Text>
+      <Button title="Scan" onPress={() => navigation.navigate('Scan')} />
+    </View>
+  );
+}
+
+function ScanScreen({ navigation }) {
+  return (
+    <View style={styles.center}>
+      <Text>Camera Scan Placeholder</Text>
+      <Button title="Identify" onPress={() => navigation.navigate('Dex')} />
+    </View>
+  );
+}
+
+function DexScreen() {
+  const discoveries = useStore(state => state.discoveries);
+  return (
+    <View style={styles.center}>
+      <Text>CritterDex ({discoveries.length})</Text>
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Map" component={MapScreen} />
+        <Stack.Screen name="Scan" component={ScanScreen} />
+        <Stack.Screen name="Dex" component={DexScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/CritterQuest/README.md
+++ b/CritterQuest/README.md
@@ -1,0 +1,8 @@
+# CritterQuest
+
+Barebones location discovery game prototype using Zustand store.
+
+Placeholder features:
+- Map and scanning flow
+- Species identification
+- Leaderboard and lure purchases

--- a/CritterQuest/package.json
+++ b/CritterQuest/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "critterquest",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {"start": "expo start"},
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "zustand": "^4.5.2",
+    "react-native-maps": "^1.3.2"
+  }
+}

--- a/HuddleUp/App.js
+++ b/HuddleUp/App.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { View, Text, Button, StyleSheet, FlatList } from 'react-native';
+
+const huddlesSlice = createSlice({
+  name: 'huddles',
+  initialState: [],
+  reducers: {
+    addHuddle: (state, action) => { state.push(action.payload); }
+  }
+});
+
+const store = configureStore({ reducer: { huddles: huddlesSlice.reducer } });
+
+function HomeScreen({ navigation }) {
+  const huddles = useSelector(state => state.huddles);
+  return (
+    <View style={styles.center}>
+      <Button title="Create" onPress={() => navigation.navigate('Create')} />
+      <FlatList data={huddles} keyExtractor={(item,i) => i.toString()} renderItem={({item}) => (
+        <Text>{item}</Text>
+      )}/>
+    </View>
+  );
+}
+
+function CreateScreen({ navigation }) {
+  const dispatch = useDispatch();
+  return (
+    <View style={styles.center}>
+      <Button title="Add Sample Huddle" onPress={() => { dispatch(huddlesSlice.actions.addHuddle('My Huddle')); navigation.goBack(); }} />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+function AppInner() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Create" component={CreateScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <AppInner />
+    </Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/HuddleUp/README.md
+++ b/HuddleUp/README.md
@@ -1,0 +1,8 @@
+# HuddleUp
+
+Prototype for time-limited group chat rooms. Uses Redux Toolkit and stack navigation.
+
+Features stubbed:
+- Real-time chat via Supabase
+- Invite links and nickname join
+- Expiration timer with in-app purchase extension

--- a/HuddleUp/package.json
+++ b/HuddleUp/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "huddleup",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
+  }
+}

--- a/PantryPal/App.js
+++ b/PantryPal/App.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+const pantrySlice = (state = [], action) => state;
+const store = configureStore({ reducer: { pantry: pantrySlice } });
+
+function PantryScreen({ navigation }) {
+  return (
+    <View style={styles.center}>
+      <Text>Pantry List Placeholder</Text>
+      <Button title="Scan" onPress={() => navigation.navigate('Scan')} />
+    </View>
+  );
+}
+
+function ScanScreen() {
+  return (
+    <View style={styles.center}>
+      <Text>Receipt Scan Placeholder</Text>
+    </View>
+  );
+}
+
+function RecipesScreen() {
+  return (
+    <View style={styles.center}>
+      <Text>Recipes Placeholder</Text>
+    </View>
+  );
+}
+
+function SettingsScreen() {
+  return (
+    <View style={styles.center}>
+      <Text>Settings Placeholder</Text>
+    </View>
+  );
+}
+
+const Tab = createBottomTabNavigator();
+
+function AppInner() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Pantry" component={PantryScreen} />
+        <Tab.Screen name="Scan" component={ScanScreen} />
+        <Tab.Screen name="Recipes" component={RecipesScreen} />
+        <Tab.Screen name="Settings" component={SettingsScreen} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <AppInner />
+    </Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/PantryPal/README.md
+++ b/PantryPal/README.md
@@ -1,0 +1,8 @@
+# PantryPal
+
+Minimal demo of a pantry tracking app. Includes tab navigation with Redux Toolkit store.
+
+Features to add:
+- Receipt OCR parsing
+- Expiration reminders
+- Recipe API integration

--- a/PantryPal/package.json
+++ b/PantryPal/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "pantrypal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {"start": "expo start"},
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/bottom-tabs": "^7.0.0",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1",
+    "expo-camera": "^14.1.0"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ Current examples:
 - **FitCraft** – skeleton app demonstrating bottom tab navigation and zustand.
 - **HabitTrackerAICoach** – sample habit tracker using Redux Toolkit.
 - **DreamWeaverAI** – basic stack navigation setup for dream journaling features.
+- **VibePulse** – simple mood tracker demo under `VibePulse/`.
+- **AuraSnap** – selfie aura generator placeholder using zustand.
+- **HuddleUp** – ephemeral group chat demo with Redux Toolkit.
+- **PantryPal** – pantry tracker tabs example with Redux.
+- **CritterQuest** – location discovery game starter with zustand.
+- **StorySphere** – collaborative story writing prototype.
 
 These prototypes can be expanded with Firebase, AI integrations, and additional screens as described in their respective README files.
-Each project uses Expo and Redux for state management. Additional apps can be added following a similar structure.
-- **VibePulse**: simple mood tracker demo under `VibePulse/`.

--- a/StorySphere/App.js
+++ b/StorySphere/App.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { View, Text, Button, StyleSheet } from 'react-native';
+
+const storiesSlice = createSlice({
+  name: 'stories',
+  initialState: [],
+  reducers: {
+    addStory: (state, action) => { state.push(action.payload); }
+  }
+});
+
+const store = configureStore({ reducer: { stories: storiesSlice.reducer } });
+
+function HomeScreen({ navigation }) {
+  const stories = useSelector(state => state.stories);
+  return (
+    <View style={styles.center}>
+      <Button title="New Story" onPress={() => navigation.navigate('Create')} />
+      {stories.map((s,i) => (<Text key={i}>{s}</Text>))}
+    </View>
+  );
+}
+
+function CreateScreen({ navigation }) {
+  const dispatch = useDispatch();
+  return (
+    <View style={styles.center}>
+      <Button title="Add Sample Story" onPress={() => { dispatch(storiesSlice.actions.addStory('My Story')); navigation.goBack(); }} />
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+function AppInner() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Create" component={CreateScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+export default function App() {
+  return (
+    <Provider store={store}>
+      <AppInner />
+    </Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/StorySphere/README.md
+++ b/StorySphere/README.md
@@ -1,0 +1,7 @@
+# StorySphere
+
+Small example for collaborative storytelling using Redux Toolkit.
+
+Future work:
+- Turn-based contributions
+- Reveal tokens and notifications

--- a/StorySphere/package.json
+++ b/StorySphere/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "storysphere",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {"start": "expo start"},
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal prototypes for AuraSnap, HuddleUp, PantryPal, CritterQuest, StorySphere
- update root README with new app list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cd4b13360833287c1f02912bc6297