### PR TITLE
Add PersonalStylist skeleton app

### DIFF
--- a/PersonalStylist/App.js
+++ b/PersonalStylist/App.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Provider as PaperProvider } from 'react-native-paper';
+import CameraScreen from './src/screens/CameraScreen';
+import SuggestionsScreen from './src/screens/SuggestionsScreen';
+import PurchasesScreen from './src/screens/PurchasesScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <PaperProvider>
+      <NavigationContainer>
+        <Tab.Navigator>
+          <Tab.Screen name="Camera" component={CameraScreen} />
+          <Tab.Screen name="Suggestions" component={SuggestionsScreen} />
+          <Tab.Screen name="Purchases" component={PurchasesScreen} />
+        </Tab.Navigator>
+      </NavigationContainer>
+    </PaperProvider>
+  );
+}

--- a/PersonalStylist/README.md
+++ b/PersonalStylist/README.md
@@ -1,0 +1,3 @@
+# Personal Stylist
+
+This is a simple React Native app skeleton demonstrating an AI-powered personal stylist concept. It uses Expo, React Navigation, and React Native Paper. Screens include a camera preview, outfit suggestions, and purchase history. Placeholder content is provided for further expansion.

--- a/PersonalStylist/package.json
+++ b/PersonalStylist/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "personal-stylist",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-camera": "^4.2.1",
+    "react-native-paper": "^5.0.0",
+    "@react-navigation/bottom-tabs": "^6.5.7"
+  }
+}

--- a/PersonalStylist/src/screens/CameraScreen.js
+++ b/PersonalStylist/src/screens/CameraScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function CameraScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Camera Preview Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});

--- a/PersonalStylist/src/screens/PurchasesScreen.js
+++ b/PersonalStylist/src/screens/PurchasesScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function PurchasesScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Purchase History Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});

--- a/PersonalStylist/src/screens/SuggestionsScreen.js
+++ b/PersonalStylist/src/screens/SuggestionsScreen.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Card } from 'react-native-paper';
+
+export default function SuggestionsScreen() {
+  return (
+    <View style={styles.container}>
+      <Card style={styles.card}>
+        <Card.Title title="Suggested Outfit" />
+        <Card.Content>
+          <Text>Outfit details go here.</Text>
+        </Card.Content>
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16
+  },
+  card: {
+    marginBottom: 16
+  }
+});


### PR DESCRIPTION
## Summary
- add new `PersonalStylist` Expo project
- include placeholder screens and navigation

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687cada121448332bc2fa1edc2e19e8a