### PR TITLE
Add skeleton implementations for new app ideas

### DIFF
--- a/BeeWatch/App.js
+++ b/BeeWatch/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  sightings: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const Camera = () => <Placeholder name="Camera" />;
+const ResultCard = () => <Placeholder name="Result" />;
+const Map = () => {
+  const count = useStore(state => state.sightings.length);
+  return (
+    <View style={styles.center}>
+      <Text>Map ({count} sightings)</Text>
+    </View>
+  );
+};
+const Leaderboard = () => <Placeholder name="Leaderboard" />;
+const DataExport = () => <Placeholder name="Data Export" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Camera" component={Camera} />
+        <Tab.Screen name="Result" component={ResultCard} />
+        <Tab.Screen name="Map" component={Map} />
+        <Tab.Screen name="Leaderboard" component={Leaderboard} />
+        <Tab.Screen name="Export" component={DataExport} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/BeeWatch/README.md
+++ b/BeeWatch/README.md
@@ -1,0 +1,3 @@
+# BeeWatch
+
+Citizen science bee logging app. Tabs for Camera, Result Card, Map, Leaderboard and Data Export with zustand to store sightings.

--- a/BeeWatch/package.json
+++ b/BeeWatch/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "beewatch",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/CarCircle/App.js
+++ b/CarCircle/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  rides: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const Dashboard = () => <Placeholder name="Circle Dashboard" />;
+const RouteMap = () => <Placeholder name="Route Map" />;
+const CostSplit = () => <Placeholder name="Cost Split" />;
+const RatingModal = () => <Placeholder name="Rating" />;
+const Stats = () => {
+  const count = useStore(state => state.rides.length);
+  return (
+    <View style={styles.center}>
+      <Text>Stats ({count} rides)</Text>
+    </View>
+  );
+};
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Dashboard" component={Dashboard} />
+        <Tab.Screen name="Route" component={RouteMap} />
+        <Tab.Screen name="Costs" component={CostSplit} />
+        <Tab.Screen name="Rating" component={RatingModal} />
+        <Tab.Screen name="Stats" component={Stats} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/CarCircle/README.md
+++ b/CarCircle/README.md
@@ -1,0 +1,3 @@
+# CarCircle
+
+Skeleton carpool coordinator. Tabs for Dashboard, Route Map, Cost Split, Rating and Stats with zustand store for rides.

--- a/CarCircle/package.json
+++ b/CarCircle/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "carcircle",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/ChefBattleLive/App.js
+++ b/ChefBattleLive/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  battles: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const Lobby = () => <Placeholder name="Lobby" />;
+const LivePlayer = () => <Placeholder name="Live Player" />;
+const TipWallet = () => <Placeholder name="Tip Wallet" />;
+const ReplayFeed = () => <Placeholder name="Replay Feed" />;
+const HostDashboard = () => {
+  const count = useStore(state => state.battles.length);
+  return (
+    <View style={styles.center}>
+      <Text>Host Dashboard ({count})</Text>
+    </View>
+  );
+};
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Lobby" component={Lobby} />
+        <Tab.Screen name="Live" component={LivePlayer} />
+        <Tab.Screen name="Wallet" component={TipWallet} />
+        <Tab.Screen name="Replays" component={ReplayFeed} />
+        <Tab.Screen name="Host" component={HostDashboard} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/ChefBattleLive/README.md
+++ b/ChefBattleLive/README.md
@@ -1,0 +1,3 @@
+# ChefBattle Live
+
+Simple layout for livestream cook-offs. Includes Lobby, Live Player, Tip Wallet, Replay Feed and Host Dashboard tabs with zustand store.

--- a/ChefBattleLive/package.json
+++ b/ChefBattleLive/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chefbattle-live",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/CryptoHabit/App.js
+++ b/CryptoHabit/App.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  transactions: [],
+  blocks: 0,
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+function Dashboard() {
+  const blocks = useStore(state => state.blocks);
+  return (
+    <View style={styles.center}>
+      <Text>Dashboard - Blocks: {blocks}</Text>
+    </View>
+  );
+}
+
+function Transactions() {
+  const txs = useStore(state => state.transactions);
+  return (
+    <View style={styles.center}>
+      <Text>Transactions ({txs.length})</Text>
+    </View>
+  );
+}
+
+const AutoRules = () => <Placeholder name="Auto Rules" />;
+const PDFExport = () => <Placeholder name="PDF Export" />;
+const Settings = () => <Placeholder name="Settings" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Dashboard" component={Dashboard} />
+        <Tab.Screen name="Transactions" component={Transactions} />
+        <Tab.Screen name="Rules" component={AutoRules} />
+        <Tab.Screen name="Export" component={PDFExport} />
+        <Tab.Screen name="Settings" component={Settings} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/CryptoHabit/README.md
+++ b/CryptoHabit/README.md
@@ -1,0 +1,3 @@
+# CryptoHabit
+
+Skeleton app showing tab navigation for crypto round-up savings. Screens include Dashboard, Transactions, Auto Rules, PDF Export and Settings. Data stores use zustand.

--- a/CryptoHabit/package.json
+++ b/CryptoHabit/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cryptohabit",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/FitFlash/App.js
+++ b/FitFlash/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  xp: 0,
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const DeckSwipe = () => <Placeholder name="Deck Swipe" />;
+const RepCounter = () => <Placeholder name="Rep Counter" />;
+const Summary = () => <Placeholder name="Summary" />;
+const XPTracker = () => {
+  const xp = useStore(state => state.xp);
+  return (
+    <View style={styles.center}>
+      <Text>XP: {xp}</Text>
+    </View>
+  );
+};
+const Store = () => <Placeholder name="Store" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Deck" component={DeckSwipe} />
+        <Tab.Screen name="Counter" component={RepCounter} />
+        <Tab.Screen name="Summary" component={Summary} />
+        <Tab.Screen name="XP" component={XPTracker} />
+        <Tab.Screen name="Store" component={Store} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/FitFlash/README.md
+++ b/FitFlash/README.md
@@ -1,0 +1,3 @@
+# FitFlash
+
+Workout flashcard idea with tabs for Deck Swipe, Rep Counter, Summary, XP Tracker and Store. Simple zustand store tracks XP.

--- a/FitFlash/package.json
+++ b/FitFlash/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fitflash",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/NoteCube/App.js
+++ b/NoteCube/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  cubes: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const CubeView = () => {
+  const count = useStore(state => state.cubes.length);
+  return (
+    <View style={styles.center}>
+      <Text>Cube View ({count})</Text>
+    </View>
+  );
+};
+const CardEditor = () => <Placeholder name="Card Editor" />;
+const Navigator = () => <Placeholder name="Navigator" />;
+const Export = () => <Placeholder name="Export" />;
+const ThemeStore = () => <Placeholder name="Theme Store" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Cube" component={CubeView} />
+        <Tab.Screen name="Editor" component={CardEditor} />
+        <Tab.Screen name="Navigator" component={Navigator} />
+        <Tab.Screen name="Export" component={Export} />
+        <Tab.Screen name="Themes" component={ThemeStore} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/NoteCube/README.md
+++ b/NoteCube/README.md
@@ -1,0 +1,3 @@
+# NoteCube
+
+Starter app for organizing notes on a rotatable cube. Tabs for Cube View, Card Editor, Navigator, Export and Theme Store with zustand for cube state.

--- a/NoteCube/package.json
+++ b/NoteCube/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "notecube",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/Printify3D/App.js
+++ b/Printify3D/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  models: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const Catalog = () => {
+  const count = useStore(state => state.models.length);
+  return (
+    <View style={styles.center}>
+      <Text>Catalog ({count})</Text>
+    </View>
+  );
+};
+const ModelDetail = () => <Placeholder name="Model Detail" />;
+const ARViewer = () => <Placeholder name="AR Viewer" />;
+const PrintOrder = () => <Placeholder name="Print Order" />;
+const SellerDashboard = () => <Placeholder name="Seller Dashboard" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Catalog" component={Catalog} />
+        <Tab.Screen name="Detail" component={ModelDetail} />
+        <Tab.Screen name="AR" component={ARViewer} />
+        <Tab.Screen name="Print" component={PrintOrder} />
+        <Tab.Screen name="Seller" component={SellerDashboard} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/Printify3D/README.md
+++ b/Printify3D/README.md
@@ -1,0 +1,3 @@
+# Printify3D
+
+Marketplace concept for mobile 3D printing. Tabs for Catalog, Model Detail, AR Viewer, Print Order and Seller Dashboard using zustand to store models.

--- a/Printify3D/package.json
+++ b/Printify3D/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "printify3d",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/SoundQuest/App.js
+++ b/SoundQuest/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  badges: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const QuestMap = () => <Placeholder name="Quest Map" />;
+const Recorder = () => <Placeholder name="Recorder" />;
+const Album = () => {
+  const count = useStore(state => state.badges.length);
+  return (
+    <View style={styles.center}>
+      <Text>Badge Album ({count})</Text>
+    </View>
+  );
+};
+const TradeChat = () => <Placeholder name="Trade Chat" />;
+const Leaderboard = () => <Placeholder name="Leaderboard" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Map" component={QuestMap} />
+        <Tab.Screen name="Record" component={Recorder} />
+        <Tab.Screen name="Album" component={Album} />
+        <Tab.Screen name="Trade" component={TradeChat} />
+        <Tab.Screen name="Leaderboard" component={Leaderboard} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/SoundQuest/README.md
+++ b/SoundQuest/README.md
@@ -1,0 +1,3 @@
+# SoundQuest
+
+Prototype scavenger hunt for recording unique sounds. Tabs include Quest Map, Recorder, Badge Album, Trade Chat and Leaderboard. Uses zustand for simple badge store.

--- a/SoundQuest/package.json
+++ b/SoundQuest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "soundquest",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/TrendTrackLite/App.js
+++ b/TrendTrackLite/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  alerts: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const Accounts = () => <Placeholder name="Accounts" />;
+const TrendGraph = () => <Placeholder name="Trend Graph" />;
+const AlertFeed = () => {
+  const count = useStore(state => state.alerts.length);
+  return (
+    <View style={styles.center}>
+      <Text>Alert Feed ({count})</Text>
+    </View>
+  );
+};
+const SponsorCalc = () => <Placeholder name="Sponsor Calc" />;
+const Subscription = () => <Placeholder name="Subscription" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Accounts" component={Accounts} />
+        <Tab.Screen name="Trends" component={TrendGraph} />
+        <Tab.Screen name="Alerts" component={AlertFeed} />
+        <Tab.Screen name="Sponsors" component={SponsorCalc} />
+        <Tab.Screen name="Subscription" component={Subscription} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/TrendTrackLite/README.md
+++ b/TrendTrackLite/README.md
@@ -1,0 +1,3 @@
+# TrendTrack Lite
+
+Dashboard prototype for monitoring social metrics. Tabs for Accounts, Trends, Alerts, Sponsor Calculator and Subscription with zustand-based alerts store.

--- a/TrendTrackLite/package.json
+++ b/TrendTrackLite/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "trendtrack-lite",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}

--- a/UrbanCanvas/App.js
+++ b/UrbanCanvas/App.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  walls: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const ARPaint = () => <Placeholder name="AR Paint" />;
+const WallFeed = () => {
+  const count = useStore(state => state.walls.length);
+  return (
+    <View style={styles.center}>
+      <Text>Wall Feed ({count})</Text>
+    </View>
+  );
+};
+const ReplayPlayer = () => <Placeholder name="Replay" />;
+const Store = () => <Placeholder name="Store" />;
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Paint" component={ARPaint} />
+        <Tab.Screen name="Feed" component={WallFeed} />
+        <Tab.Screen name="Replay" component={ReplayPlayer} />
+        <Tab.Screen name="Store" component={Store} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/UrbanCanvas/README.md
+++ b/UrbanCanvas/README.md
@@ -1,0 +1,3 @@
+# UrbanCanvas
+
+AR graffiti concept with tabs for painting, wall feed, replays and store. Walls are stored in a simple zustand store.

--- a/UrbanCanvas/package.json
+++ b/UrbanCanvas/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "urbancanvas",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "zustand": "^4.3.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add new Expo skeleton apps: CryptoHabit, SoundQuest, UrbanCanvas, ChefBattle Live, NoteCube, TrendTrack Lite, BeeWatch, FitFlash, CarCircle and Printify3D
- each includes basic tab navigation with placeholder screens and zustand store

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_687d139c948483328edfaa7a69831e83