### PR TITLE
Add FitSnap skeleton

### DIFF
--- a/FitSnap/App.js
+++ b/FitSnap/App.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  trophies: [],
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+function MapScreen() {
+  return <Placeholder name="Map" />;
+}
+
+function CaptureModal() {
+  return <Placeholder name="Capture" />;
+}
+
+function Inventory() {
+  return <Placeholder name="Inventory" />;
+}
+
+function Leaderboard() {
+  return <Placeholder name="Leaderboard" />;
+}
+
+function Profile() {
+  return <Placeholder name="Profile" />;
+}
+
+function Settings() {
+  return <Placeholder name="Settings" />;
+}
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Tab.Navigator>
+        <Tab.Screen name="Map" component={MapScreen} />
+        <Tab.Screen name="Inventory" component={Inventory} />
+        <Tab.Screen name="Leaderboard" component={Leaderboard} />
+        <Tab.Screen name="Profile" component={Profile} />
+        <Tab.Screen name="Settings" component={Settings} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/FitSnap/README.md
+++ b/FitSnap/README.md
@@ -1,0 +1,3 @@
+# FitSnap
+
+Skeleton React Native app for AR trophy hunts. Includes placeholder screens for Map, Inventory, Leaderboard, Profile, and Settings using React Navigation and Zustand store.

--- a/FitSnap/app.json
+++ b/FitSnap/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "FitSnap",
+    "slug": "fitsnap",
+    "version": "1.0.0",
+    "sdkVersion": "48.0.0"
+  }
+}

--- a/FitSnap/package.json
+++ b/FitSnap/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fitsnap",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "react-navigation": "^4.4.4",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "react-native-svg": "^13.4.0",
+    "zustand": "^4.3.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add new FitSnap app skeleton using React Navigation and Zustand

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d13df48a48332b91e6a10eb317b4c