### PR TITLE
Add ChoreQuest skeleton app

### DIFF
--- a/ChoreQuest/App.js
+++ b/ChoreQuest/App.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import create from 'zustand';
+
+const useStore = create(set => ({ user: null, setUser: user => set({ user }) }));
+
+function Placeholder({ title }) {
+  return (
+    <View style={styles.center}>
+      <Text>{title}</Text>
+    </View>
+  );
+}
+
+// Auth Flow
+function SplashScreen() { return <Placeholder title="Splash" />; }
+function WelcomeScreen() { return <Placeholder title="Welcome" />; }
+function AuthScreen() { return <Placeholder title="Auth" />; }
+
+// Main Tabs
+function DashboardScreen() { return <Placeholder title="Dashboard" />; }
+function ChoreListScreen() { return <Placeholder title="Chore List" />; }
+function LeaderboardScreen() { return <Placeholder title="Leaderboard" />; }
+function ProfileScreen() { return <Placeholder title="Profile" />; }
+
+const AuthStack = createNativeStackNavigator();
+function AuthNavigator() {
+  return (
+    <AuthStack.Navigator screenOptions={{ headerShown: false }}>
+      <AuthStack.Screen name="Splash" component={SplashScreen} />
+      <AuthStack.Screen name="Welcome" component={WelcomeScreen} />
+      <AuthStack.Screen name="Auth" component={AuthScreen} />
+    </AuthStack.Navigator>
+  );
+}
+
+const Tab = createBottomTabNavigator();
+function AppTabs() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={DashboardScreen} />
+      <Tab.Screen name="Chores" component={ChoreListScreen} />
+      <Tab.Screen name="Leaderboard" component={LeaderboardScreen} />
+      <Tab.Screen name="Profile" component={ProfileScreen} />
+    </Tab.Navigator>
+  );
+}
+
+export default function App() {
+  const user = useStore(state => state.user);
+  return (
+    <NavigationContainer>
+      {user ? <AppTabs /> : <AuthNavigator />}
+      <StatusBar style="auto" />
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' }
+});

--- a/ChoreQuest/README.md
+++ b/ChoreQuest/README.md
@@ -1,0 +1,12 @@
+# ChoreQuest
+
+This is a minimal React Native Expo skeleton for the **ChoreQuest** app idea. It sets up basic navigation and state management using Zustand. Screens are placeholders ready to be expanded.
+
+## Running
+
+```bash
+npm install
+npm start
+```
+
+This will start the Expo development server so you can run the app on a simulator or device.

--- a/ChoreQuest/babel.config.js
+++ b/ChoreQuest/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/ChoreQuest/index.js
+++ b/ChoreQuest/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/ChoreQuest/package.json
+++ b/ChoreQuest/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "chorequest",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "~48.0.18",
+    "react": "18.2.0",
+    "react-native": "0.71.8",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-screens": "~3.20.0",
+    "react-native-safe-area-context": "4.5.0",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9",
+    "expo-status-bar": "^1.4.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add new Expo project `ChoreQuest`
- implement basic navigation and state management using Zustand
- include placeholder screens for auth flow and main tabs

## Testing
- `npm install` and `npm start` in `ChoreQuest`

------
https://chatgpt.com/codex/tasks/task_e_687d15d2d6848332ad8879e366a8b5f1