### PR TITLE
Add ScriptSnap skeleton app

### DIFF
--- a/ScriptSnap/App.js
+++ b/ScriptSnap/App.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import CameraScreen from './src/screens/CameraScreen';
+import ParsePreviewScreen from './src/screens/ParsePreviewScreen';
+import EditorScreen from './src/screens/EditorScreen';
+import ExportPickerScreen from './src/screens/ExportPickerScreen';
+import HistoryScreen from './src/screens/HistoryScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Camera">
+        <Stack.Screen name="Camera" component={CameraScreen} />
+        <Stack.Screen name="ParsePreview" component={ParsePreviewScreen} />
+        <Stack.Screen name="Editor" component={EditorScreen} />
+        <Stack.Screen name="ExportPicker" component={ExportPickerScreen} />
+        <Stack.Screen name="History" component={HistoryScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/ScriptSnap/README.md
+++ b/ScriptSnap/README.md
@@ -1,0 +1,14 @@
+# ScriptSnap
+
+This is a minimal React Native skeleton for the **ScriptSnap** app idea. The app allows users to photograph handwritten notes and convert them into structured markdown.
+
+The project uses **Expo** with React Navigation and Zustand for state management. Screens are placeholders ready for further implementation.
+
+## Available Screens
+- Camera
+- Parse Preview
+- Editor
+- Export Picker
+- History
+
+Run `npm install` then `npm start` to launch with Expo.

--- a/ScriptSnap/package.json
+++ b/ScriptSnap/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "scriptsnap",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/ScriptSnap/src/components/BoundingBoxOverlay.js
+++ b/ScriptSnap/src/components/BoundingBoxOverlay.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+
+export default function BoundingBoxOverlay() {
+  return <View style={styles.box} />;
+}
+
+const styles = StyleSheet.create({
+  box: {
+    width: 200,
+    height: 200,
+    borderWidth: 2,
+    borderColor: 'red'
+  }
+});

--- a/ScriptSnap/src/components/DiffViewer.js
+++ b/ScriptSnap/src/components/DiffViewer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function DiffViewer() {
+  return (
+    <View style={styles.container}>
+      <Text>Diff Viewer Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 }
+});

--- a/ScriptSnap/src/components/ExportChip.js
+++ b/ScriptSnap/src/components/ExportChip.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+export default function ExportChip({ label }) {
+  return (
+    <TouchableOpacity style={styles.chip}>
+      <Text style={styles.text}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    backgroundColor: '#ddd',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    margin: 4
+  },
+  text: { fontSize: 14 }
+});

--- a/ScriptSnap/src/components/MarkdownPreview.js
+++ b/ScriptSnap/src/components/MarkdownPreview.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function MarkdownPreview({ text }) {
+  return (
+    <View style={styles.container}>
+      <Text>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 }
+});

--- a/ScriptSnap/src/screens/CameraScreen.js
+++ b/ScriptSnap/src/screens/CameraScreen.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function CameraScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Camera Placeholder</Text>
+      <Button title="Next" onPress={() => navigation.navigate('ParsePreview')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex:1, alignItems:'center', justifyContent:'center' },
+  text: { fontSize:18 }
+});

--- a/ScriptSnap/src/screens/EditorScreen.js
+++ b/ScriptSnap/src/screens/EditorScreen.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function EditorScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Editor Placeholder</Text>
+      <Button title="Export" onPress={() => navigation.navigate('ExportPicker')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container:{ flex:1, alignItems:'center', justifyContent:'center' },
+  text:{ fontSize:18 }
+});

--- a/ScriptSnap/src/screens/ExportPickerScreen.js
+++ b/ScriptSnap/src/screens/ExportPickerScreen.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function ExportPickerScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Export Picker Placeholder</Text>
+      <Button title="History" onPress={() => navigation.navigate('History')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container:{ flex:1, alignItems:'center', justifyContent:'center' },
+  text:{ fontSize:18 }
+});

--- a/ScriptSnap/src/screens/HistoryScreen.js
+++ b/ScriptSnap/src/screens/HistoryScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HistoryScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>History Placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container:{ flex:1, alignItems:'center', justifyContent:'center' },
+  text:{ fontSize:18 }
+});

--- a/ScriptSnap/src/screens/ParsePreviewScreen.js
+++ b/ScriptSnap/src/screens/ParsePreviewScreen.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+
+export default function ParsePreviewScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Parse Preview Placeholder</Text>
+      <Button title="Edit" onPress={() => navigation.navigate('Editor')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container:{ flex:1, alignItems:'center', justifyContent:'center' },
+  text:{ fontSize:18 }
+});


### PR DESCRIPTION
## Summary
- add initial React Native project for ScriptSnap
- include placeholder screens and components

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687d1bd6afd08332ba61db76b4b7a820