### PR TITLE
Add FitSnap skeleton app

### DIFF
--- a/FitSnap/App.js
+++ b/FitSnap/App.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useColorScheme } from 'react-native';
+import create from 'zustand';
+import OnboardingScreen from './src/screens/OnboardingScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
+import WorkoutScreen from './src/screens/WorkoutScreen';
+import HistoryScreen from './src/screens/HistoryScreen';
+import LeaderboardScreen from './src/screens/LeaderboardScreen';
+import StoreScreen from './src/screens/StoreScreen';
+import SettingsScreen from './src/screens/SettingsScreen';
+
+const useStore = create(set => ({
+  user: null,
+  setUser: user => set({ user })
+}));
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  const scheme = useColorScheme();
+  const user = useStore(state => state.user);
+  return (
+    <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {!user ? (
+          <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        ) : (
+          <>
+            <Stack.Screen name="Dashboard" component={DashboardScreen} />
+            <Stack.Screen name="Workout" component={WorkoutScreen} />
+            <Stack.Screen name="History" component={HistoryScreen} />
+            <Stack.Screen name="Leaderboard" component={LeaderboardScreen} />
+            <Stack.Screen name="Store" component={StoreScreen} />
+            <Stack.Screen name="Settings" component={SettingsScreen} />
+          </>
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/FitSnap/README.md
+++ b/FitSnap/README.md
@@ -1,0 +1,14 @@
+# FitSnap
+
+A minimal React Native skeleton for the **FitSnap** app. The goal is to provide a starting point for AI-guided micro-workouts with a simple navigation structure and Zustand state store.
+
+## Screens
+- Onboarding
+- Dashboard
+- Workout
+- History
+- Leaderboard
+- Store
+- Settings
+
+All advanced functionality like camera rep counting and Supabase backend are left as future improvements.

--- a/FitSnap/app.json
+++ b/FitSnap/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "FitSnap",
+    "slug": "fitsnap",
+    "version": "1.0.0",
+    "sdkVersion": "51.0.0"
+  }
+}

--- a/FitSnap/index.js
+++ b/FitSnap/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/FitSnap/package.json
+++ b/FitSnap/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "fitsnap",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "zustand": "^4.5.2",
+    "react-native-reanimated": "^3.3.0",
+    "expo-camera": "^14.1.0",
+    "expo-status-bar": "^1.5.2"
+  }
+}

--- a/FitSnap/src/screens/DashboardScreen.js
+++ b/FitSnap/src/screens/DashboardScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function DashboardScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Dashboard Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/screens/HistoryScreen.js
+++ b/FitSnap/src/screens/HistoryScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function HistoryScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>History Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/screens/LeaderboardScreen.js
+++ b/FitSnap/src/screens/LeaderboardScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function LeaderboardScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Leaderboard Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/screens/OnboardingScreen.js
+++ b/FitSnap/src/screens/OnboardingScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+export default function OnboardingScreen() {
+  const navigation = useNavigation();
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Welcome to FitSnap!</Text>
+      <Button title="Get Started" onPress={() => navigation.replace('Dashboard')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24, marginBottom: 16 }
+});

--- a/FitSnap/src/screens/SettingsScreen.js
+++ b/FitSnap/src/screens/SettingsScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Settings Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/screens/StoreScreen.js
+++ b/FitSnap/src/screens/StoreScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function StoreScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Store Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/screens/WorkoutScreen.js
+++ b/FitSnap/src/screens/WorkoutScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function WorkoutScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Workout Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 24 }
+});

--- a/FitSnap/src/store/useStore.js
+++ b/FitSnap/src/store/useStore.js
@@ -1,0 +1,9 @@
+import create from 'zustand';
+
+const useStore = create(set => ({
+  xp: 0,
+  increaseXP: amt => set(state => ({ xp: state.xp + amt })),
+  reset: () => set({ xp: 0 })
+}));
+
+export default useStore;


### PR DESCRIPTION
## Summary
- add a new FitSnap project skeleton with Expo and Zustand
- include onboarding, dashboard, workout, history, leaderboard, store and settings screens

## Testing
- `npm install` within `FitSnap` *(fails: expo not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_687df33571648332a8de46f19d8cad1a