### PR TITLE
Add skeleton apps for new ideas

### DIFF
--- a/Beacon/App.js
+++ b/Beacon/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for Beacon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/Beacon/README.md
+++ b/Beacon/README.md
@@ -1,0 +1,3 @@
+# Beacon
+
+Placeholder skeleton for the Beacon app idea.

--- a/Beacon/package.json
+++ b/Beacon/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "beacon",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
+  }
+}

--- a/CoinQuest/App.js
+++ b/CoinQuest/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for CoinQuest</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/CoinQuest/README.md
+++ b/CoinQuest/README.md
@@ -1,0 +1,3 @@
+# CoinQuest
+
+Placeholder skeleton for the CoinQuest app idea.

--- a/CoinQuest/package.json
+++ b/CoinQuest/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "coinquest",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
+  }
+}

--- a/FocusForge/App.js
+++ b/FocusForge/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for FocusForge</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/FocusForge/README.md
+++ b/FocusForge/README.md
@@ -1,0 +1,3 @@
+# FocusForge
+
+Placeholder skeleton for the FocusForge app idea.

--- a/FocusForge/package.json
+++ b/FocusForge/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "focusforge",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
+  }
+}

--- a/HomeHive/App.js
+++ b/HomeHive/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for HomeHive</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/HomeHive/README.md
+++ b/HomeHive/README.md
@@ -1,0 +1,3 @@
+# HomeHive
+
+Placeholder skeleton for the HomeHive app idea.

--- a/HomeHive/package.json
+++ b/HomeHive/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "homehive",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/Itinero/App.js
+++ b/Itinero/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for Itinero</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/Itinero/README.md
+++ b/Itinero/README.md
@@ -1,0 +1,3 @@
+# Itinero
+
+Placeholder skeleton for the Itinero app idea.

--- a/Itinero/package.json
+++ b/Itinero/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "itinero",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/LocalLode/App.js
+++ b/LocalLode/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for LocalLode</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/LocalLode/README.md
+++ b/LocalLode/README.md
@@ -1,0 +1,3 @@
+# LocalLode
+
+Placeholder skeleton for the LocalLode app idea.

--- a/LocalLode/package.json
+++ b/LocalLode/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "locallode",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/PartPal/App.js
+++ b/PartPal/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for PartPal</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/PartPal/README.md
+++ b/PartPal/README.md
@@ -1,0 +1,3 @@
+# PartPal
+
+Placeholder skeleton for the PartPal app idea.

--- a/PartPal/package.json
+++ b/PartPal/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "partpal",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/Scanavore/App.js
+++ b/Scanavore/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for Scanavore</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/Scanavore/README.md
+++ b/Scanavore/README.md
@@ -1,0 +1,3 @@
+# Scanavore
+
+Placeholder skeleton for the Scanavore app idea.

--- a/Scanavore/package.json
+++ b/Scanavore/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "scanavore",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/Sketchplate/App.js
+++ b/Sketchplate/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for Sketchplate</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/Sketchplate/README.md
+++ b/Sketchplate/README.md
@@ -1,0 +1,3 @@
+# Sketchplate
+
+Placeholder skeleton for the Sketchplate app idea.

--- a/Sketchplate/package.json
+++ b/Sketchplate/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "sketchplate",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}

--- a/SkillSprint/App.js
+++ b/SkillSprint/App.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Placeholder for SkillSprint</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  title: { fontSize: 18, fontWeight: 'bold' }
+});

--- a/SkillSprint/README.md
+++ b/SkillSprint/README.md
@@ -1,0 +1,3 @@
+# SkillSprint
+
+Placeholder skeleton for the SkillSprint app idea.

--- a/SkillSprint/package.json
+++ b/SkillSprint/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "skillsprint",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold ten new React Native Expo skeleton apps
- include placeholder `App.js`, `package.json`, and `README.md` for each

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dfc35ed888332bad9a105f6e4e32e