### PR TITLE
Add SnapMeal skeleton app

### DIFF
--- a/SnapMeal/App.js
+++ b/SnapMeal/App.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StatusBar } from 'expo-status-bar';
+import { View, Text, Button } from 'react-native';
+import AuthScreen from './src/screens/AuthScreen';
+import CameraScreen from './src/screens/CameraScreen';
+import DashboardScreen from './src/screens/DashboardScreen';
+
+const Stack = createNativeStackNavigator();
+const queryClient = new QueryClient();
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <NavigationContainer>
+        <StatusBar style="auto" />
+        <Stack.Navigator>
+          <Stack.Screen name="Auth" component={AuthScreen} />
+          <Stack.Screen name="Camera" component={CameraScreen} />
+          <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </QueryClientProvider>
+  );
+}

--- a/SnapMeal/README.md
+++ b/SnapMeal/README.md
@@ -1,0 +1,8 @@
+# SnapMeal
+
+Simple skeleton for SnapMeal demo using Supabase, React Navigation, Zustand and React Query.
+
+## Setup
+1. Install dependencies with `npm install`.
+2. Set your Supabase project URL and anon key in `src/lib/supabase.js`.
+3. Run with `npm start`.

--- a/SnapMeal/package.json
+++ b/SnapMeal/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "snapmeal",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "@react-navigation/bottom-tabs": "^7.0.0",
+    "@supabase/supabase-js": "^2.39.7",
+    "@tanstack/react-query": "^5.29.1",
+    "zustand": "^4.5.2",
+    "react-hook-form": "^7.45.1",
+    "expo-camera": "^14.1.0",
+    "expo-status-bar": "^1.4.2"
+  }
+}

--- a/SnapMeal/src/api/meals.js
+++ b/SnapMeal/src/api/meals.js
@@ -1,0 +1,17 @@
+import { supabase } from '../lib/supabase';
+
+export async function fetchMeals(userId) {
+  const { data, error } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('user_id', userId)
+    .order('captured_at', { ascending: false });
+  if (error) throw error;
+  return data;
+}
+
+export async function addMeal(fields) {
+  const { data, error } = await supabase.from('meals').insert(fields).single();
+  if (error) throw error;
+  return data;
+}

--- a/SnapMeal/src/lib/supabase.js
+++ b/SnapMeal/src/lib/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://your-project.supabase.co';
+const supabaseAnonKey = 'public-anon-key';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/SnapMeal/src/screens/AuthScreen.js
+++ b/SnapMeal/src/screens/AuthScreen.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import { supabase } from '../lib/supabase';
+import { useAppStore } from '../state/useAppStore';
+
+export default function AuthScreen({ navigation }) {
+  const setSession = useAppStore(state => state.setSession);
+
+  async function signIn() {
+    const { data, error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+    if (error) console.log('Sign in error', error);
+    else setSession(data.session);
+    navigation.replace('Dashboard');
+  }
+
+  return (
+    <View style={styles.center}>
+      <Button title="Sign In with Google" onPress={signIn} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/SnapMeal/src/screens/CameraScreen.js
+++ b/SnapMeal/src/screens/CameraScreen.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+import { Camera } from 'expo-camera';
+
+export default function CameraScreen({ navigation }) {
+  return (
+    <View style={styles.center}>
+      <Button title="Capture Meal" onPress={() => navigation.replace('Dashboard')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+});

--- a/SnapMeal/src/screens/DashboardScreen.js
+++ b/SnapMeal/src/screens/DashboardScreen.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, Text, FlatList, Button, StyleSheet } from 'react-native';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useAppStore } from '../state/useAppStore';
+import { fetchMeals, addMeal } from '../api/meals';
+
+export default function DashboardScreen({ navigation }) {
+  const session = useAppStore(state => state.session);
+  const { data, error, isLoading } = useQuery(['meals', session?.user.id], () => fetchMeals(session.user.id), { enabled: !!session });
+
+  const mutation = useMutation(newMeal => addMeal(newMeal));
+
+  if (!session) {
+    return (
+      <View style={styles.center}>
+        <Text>Please sign in.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Button title="Log Meal" onPress={() => navigation.navigate('Camera')} />
+      {isLoading && <Text>Loading...</Text>}
+      {error && <Text>Error loading meals</Text>}
+      <FlatList
+        data={data || []}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text>{item.captured_at} - {item.total_calories} cal</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  item: { paddingVertical: 8 },
+});

--- a/SnapMeal/src/state/useAppStore.js
+++ b/SnapMeal/src/state/useAppStore.js
@@ -1,0 +1,6 @@
+import create from 'zustand';
+
+export const useAppStore = create(set => ({
+  session: null,
+  setSession: session => set({ session }),
+}));


### PR DESCRIPTION
## Summary
- add new SnapMeal skeleton app with Auth, Camera, and Dashboard screens
- include Zustand store, Supabase client, and basic meal API helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e24be75a8833298ebd92ce2405622