### PR TITLE
Add SnapLearn skeleton

### DIFF
--- a/SnapLearn/App.js
+++ b/SnapLearn/App.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { View, Text, StyleSheet } from 'react-native';
+import create from 'zustand';
+
+const useStore = create(set => ({
+  lessons: [],
+  addLesson: title => set(state => ({ lessons: [...state.lessons, { id: Date.now().toString(), title }] })),
+}));
+
+function Placeholder({ name }) {
+  return (
+    <View style={styles.center}>
+      <Text>{name} Screen</Text>
+    </View>
+  );
+}
+
+const OnboardingScreen = () => <Placeholder name="Onboarding" />;
+const HomeScreen = () => <Placeholder name="Home" />;
+const CaptureScreen = () => <Placeholder name="Capture" />;
+const RecognitionScreen = () => <Placeholder name="Recognition" />;
+const LessonScreen = () => <Placeholder name="Lesson" />;
+const DashboardScreen = () => <Placeholder name="Dashboard" />;
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Capture" component={CaptureScreen} />
+        <Stack.Screen name="Recognition" component={RecognitionScreen} />
+        <Stack.Screen name="Lesson" component={LessonScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/SnapLearn/README.md
+++ b/SnapLearn/README.md
@@ -1,0 +1,5 @@
+# SnapLearn
+
+Minimal skeleton for the **SnapLearn** app using Zustand for state management.
+It includes basic navigation with placeholder screens for Onboarding, Capture,
+Recognition, Lesson, and Dashboard flows.

--- a/SnapLearn/package.json
+++ b/SnapLearn/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "snaplearn",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.71.8",
+    "expo": "~48.0.18",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.7",
+    "react-native-gesture-handler": "^2.9.0",
+    "react-native-reanimated": "^2.14.4",
+    "zustand": "^4.3.9"
+  }
+}


### PR DESCRIPTION
## Summary
- add new `SnapLearn` app skeleton with basic navigation

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687e286c8adc8332be2378503cb08bfd